### PR TITLE
docs: update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ app_file: app.py
 pinned: false
 ---
 
+## Project Focus
+
+The Folio project is currently focused on the command-line interface (`src/cli`) as the primary way to interact with the portfolio analysis tools. The web interface (`src/folio/`) is considered deprecated and is not actively maintained. All core business logic resides in the `src/folib/` library.
+
 # Folio - Financial Portfolio Dashboard
 
 Folio is a powerful web-based dashboard for analyzing and optimizing your investment portfolio. Get professional-grade insights into your stocks, options, and other financial instruments with an intuitive, user-friendly interface.
 
 ## Why Folio?
 
-- **Complete Portfolio Visibility**: See your entire financial picture in one place
+- **Comprehensive Portfolio Analysis**: Get a detailed overview of your financial holdings.
 - **Smart Risk Assessment**: Understand your portfolio's risk profile with beta analysis
 - **Cash & Equivalents Detection**: Automatically identifies money market and cash-like positions
 - **Option Analytics**: Detailed metrics for options including delta exposure and notional value
@@ -26,17 +30,10 @@ Folio is a powerful web-based dashboard for analyzing and optimizing your invest
 - **Portfolio Summary**: View total exposure, beta, and allocation breakdown
 - **Position Details**: Analyze individual positions with detailed metrics
 - **Position Grouping**: Automatically groups stocks with their related options
-- **P&L Visualization**: See potential profit/loss scenarios for option strategies
 - **Filtering & Sorting**: Filter by position type and sort by various metrics
 - **Real-time Data**: Uses Yahoo Finance API for up-to-date market data
-- **Responsive Design**: Works seamlessly on desktop and mobile devices
 
 ## Getting Started
-
-### Try It Online
-
-The easiest way to try Folio is through our Hugging Face Spaces deployment:
-[https://huggingface.co/spaces/mingdom/folio](https://huggingface.co/spaces/mingdom/folio)
 
 ### Local Installation
 
@@ -70,7 +67,7 @@ The easiest way to try Folio is through our Hugging Face Spaces deployment:
 
 4. **Run the application**:
    ```bash
-   make folio
+   make cli
    ```
 
 ### Development Workflow
@@ -91,7 +88,7 @@ Our project uses Poetry for dependency management and Make for convenient comman
    make test
 
    # Start the interactive CLI (includes SPY simulator functionality)
-   make focli
+   make cli
    ```
 
 3. **Working with Poetry's environment**:
@@ -100,7 +97,7 @@ Our project uses Poetry for dependency management and Make for convenient comman
    poetry shell
 
    # After activating, you can run commands directly:
-   python -m src.folio.app
+   python -m src.cli
    pytest
    ruff check .
    ```
@@ -108,6 +105,8 @@ Our project uses Poetry for dependency management and Make for convenient comman
 For detailed Poetry commands and information, see [docs/Poetry.md](docs/Poetry.md).
 
 ### Docker Deployment
+
+**Note:** The Docker deployment runs the deprecated web interface and is not recommended for the primary CLI usage.
 
 ```bash
 # Start the application
@@ -129,23 +128,36 @@ The dashboard will be available at http://localhost:8050
 - [Project Architecture](docs/project-design.md) - Codebase structure and design
 - [Poetry Commands](docs/Poetry.md) - Detailed Poetry usage
 
-## Using Folio
+## Using Folio (CLI)
 
-1. **Upload Your Portfolio**: Use the upload button to import a CSV file with your holdings
-2. **Explore Your Data**: View summary metrics and detailed breakdowns of your investments
-3. **Filter and Sort**: Focus on specific asset types or metrics that matter to you
-4. **Analyze Positions**: Click on any position to see detailed metrics and P&L scenarios
-5. **Export or Share**: Save your analysis or share insights with your financial advisor
+The Folio CLI provides various commands to analyze your portfolio. Here's a general workflow:
+
+1. **Prepare Your Portfolio CSV**: Ensure your portfolio data is in a CSV file format. Refer to `sample-data/sample-portfolio.csv` for an example.
+2. **Run Commands**: Use commands like `portfolio`, `position`, `summary`, etc., to view different aspects of your portfolio.
+   ```bash
+   # Example: View portfolio summary
+   python -m src.cli summary --portfolio path/to/your/portfolio.csv
+   ```
+3. **Explore Options**: Most commands offer options for filtering, sorting, and customizing the output. Use the `--help` flag with any command to see available options.
+   ```bash
+   python -m src.cli summary --help
+   ```
+4. **Analyze Data**: Interpret the output to gain insights into your investments. The CLI provides detailed metrics for individual positions and overall portfolio performance.
 
 ## Sample Portfolio
 
-Not ready to upload your own data? Click the "Load Sample Portfolio" button to explore Folio with our demo data.
+You can use the sample portfolio data located at `sample-data/sample-portfolio.csv` to explore Folio's CLI features.
+
+For example, to view the summary of the sample portfolio:
+```bash
+python -m src.cli summary --portfolio sample-data/sample-portfolio.csv
+```
 
 ## Privacy & Security
 
-- **Your Data Stays Private**: All analysis happens in your browser or local environment
-- **No Account Required**: Use Folio without creating an account or sharing personal information
-- **Open Source**: All code is transparent and available for review
+- **Your Data Stays Private**: All analysis happens in your local environment.
+- **No Account Required**: Use Folio without creating an account or sharing personal information.
+- **Open Source**: All code is transparent and available for review.
 
 ## License
 

--- a/docs/project-design.md
+++ b/docs/project-design.md
@@ -4,6 +4,8 @@ globs: *
 alwaysApply: true
 ---
 
+> **Important:** The web interface (`src/folio/`) described in this document is deprecated and no longer actively maintained. The project's current focus is on the CLI (`src/cli/`) and the core library (`src/folib/`). Parts of this document related to the web interface are kept for historical context but may not reflect current development.
+
 # Folio Project Design
 
 This document outlines how the Folio codebase is structured and how data flows through the application. Folio provides tools for analyzing and visualizing investment portfolios, with a focus on stocks and options, through both a web-based dashboard and a command-line interface (CLI).
@@ -12,8 +14,8 @@ This document outlines how the Folio codebase is structured and how data flows t
 
 Folio is a Python-based application that provides comprehensive portfolio analysis capabilities through multiple interfaces:
 
-1. **Web Interface (`src/folio/`)**: A Dash-based web application for visualizing portfolio data
-2. **CLI Interface (`src/cli/`)**: A command-line interface for portfolio analysis and simulation
+1. **Web Interface (`src/folio/`)**: A Dash-based web application for visualizing portfolio data. **(Deprecated)**
+2. **CLI Interface (`src/cli/`)**: A command-line interface for portfolio analysis and simulation. This is the primary interface for the application.
 
 Both interfaces leverage the core library (`src/folib/`) for business logic, following our strict separation of concerns principles. The core library provides a functional-first approach to portfolio analysis with clear boundaries between layers.
 
@@ -35,7 +37,7 @@ src/
 │       ├── portfolio_service.py  # Portfolio processing
 │       ├── position_service.py   # Position analysis
 │       ├── simulation_service.py # Portfolio simulation
-├── folio/                  # Web interface (Dash)
+├── folio/                  # Web interface (Dash) (deprecated)
 │   ├── app.py              # Main Dash application
 │   ├── components/         # UI components
 ├── cli/                    # Command-line interface
@@ -89,6 +91,8 @@ Orchestrates the lower layers to fulfill specific use cases:
 - **simulation_service.py**: Portfolio simulation
 
 ## Web Interface (`src/folio/`)
+
+**Note:** This component is deprecated, and the information below is for historical reference. The web interface is no longer actively maintained.
 
 The web interface is built with Dash and provides a visual dashboard for portfolio analysis:
 
@@ -204,9 +208,9 @@ The codebase strictly separates concerns:
 
 Folio can run in multiple deployment environments:
 
-- **Local Development**: Running directly on a developer's machine
-- **Docker Container**: Running in a containerized environment
-- **Hugging Face Spaces**: Deployed as a Hugging Face Space for public access
+- **Local Development**: Running directly on a developer's machine (primarily for CLI and core library development).
+- **Docker Container**: Running in a containerized environment. Note that the default Docker setup runs the deprecated web interface.
+- **Hugging Face Spaces**: Deployed as a Hugging Face Space for public access. This deploys the deprecated web interface.
 
 The application detects its environment and adjusts settings accordingly, such as cache directories and logging behavior.
 
@@ -233,8 +237,8 @@ Tests are organized to mirror the structure of the source code, with test files 
 
 Folio is designed with a clean architecture that separates concerns and promotes maintainability:
 
-- **Core Library (`src/folib/`)**: Contains all business logic in a functional-first approach
-- **Web Interface (`src/folio/`)**: Provides a visual dashboard using Dash
-- **CLI Interface (`src/cli/`)**: Provides a command-line tool for portfolio analysis
+- **Core Library (`src/folib/`)**: Contains all business logic in a functional-first approach. This is the foundation of the application.
+- **CLI Interface (`src/cli/`)**: Provides a command-line tool for portfolio analysis. This is the primary and actively developed interface.
+- **Web Interface (`src/folio/`)**: (Deprecated) Provided a visual dashboard using Dash. This interface is no longer maintained.
 
-This architecture makes the codebase maintainable, testable, and extensible, allowing for easy addition of new features and improvements.
+This architecture makes the codebase maintainable, testable, and extensible, allowing for easy addition of new features and improvements, primarily focused on the CLI and core library.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1,6 +1,6 @@
 # Folio CLI
 
-A command-line interface for portfolio analysis and simulation, leveraging the `folib` library for core business logic.
+This is the main and actively developed interface for the Folio project, providing powerful command-line tools for portfolio analysis and simulation. It leverages the `folib` library for core business logic.
 
 ## Features
 


### PR DESCRIPTION
This involves changes to various documentation files, including the main README, project design document, CLI README, and other documents within the /docs directory.

Key changes:
- Clarified that `src/cli` is the primary interface and `src/folib` contains the core logic.
- Marked the web interface (`src/folio/`) as deprecated across the documentation.
- Updated "Getting Started" and development workflow instructions to prioritize CLI usage.
- Added notes to older plans and specifications regarding the deprecated status of web components.